### PR TITLE
fix(missing props): Add operationId and tags

### DIFF
--- a/disney/disney-characters-openapi3_0.yaml
+++ b/disney/disney-characters-openapi3_0.yaml
@@ -1,17 +1,22 @@
 openapi: 3.0.0
 info:
   version: 1.0.0
-  title: 'Disney Characters API'
-  description: 'An API to get information on Disney characters. The original docs can be accessed on https://disneyapi.dev/docs and additional specs are on https://github.com/ManuCastrillonM/disney-api'
+  title: "Disney Characters API"
+  description: "An API to get information on Disney characters. The original docs can be accessed on https://disneyapi.dev/docs and additional specs are on https://github.com/ManuCastrillonM/disney-api"
+  contact:
+    url: "https://github.com/manuCastrillonM"
 servers:
-- url: https://api.disneyapi.dev
-  description: 'Main server'
+  - url: https://api.disneyapi.dev
+    description: "Main server"
 paths:
   /characters:
     get:
+      tags:
+        - "Characters"
       description: Retrieves a paginated list of available characters
+      operationId: GetAllCharaters
       responses:
-        '200':
+        "200":
           description: Successfully returned a list of characters
           content:
             application/json:
@@ -72,30 +77,33 @@ paths:
                           description: API URL for the character's detail.
   /character:
     get:
+      tags:
+        - "Characters"
       description: Searches for a character based on query parameters
+      operationId: GetCharacterByQueryParameters
       parameters:
-      - name: name
-        in: query
-        schema:
-          type: string
-      - name: films
-        in: query
-        schema:
-          type: string
-      - name: tvShows
-        in: query
-        schema:
-          type: string
-      - name: parkAttractions
-        in: query
-        schema:
-          type: string
-      - name: videoGames
-        in: query
-        schema:
-          type: string
+        - name: name
+          in: query
+          schema:
+            type: string
+        - name: films
+          in: query
+          schema:
+            type: string
+        - name: tvShows
+          in: query
+          schema:
+            type: string
+        - name: parkAttractions
+          in: query
+          schema:
+            type: string
+        - name: videoGames
+          in: query
+          schema:
+            type: string
       responses:
-        '200':
+        "200":
           description: Successfully returned a list of characters
           content:
             application/json:
@@ -111,7 +119,7 @@ paths:
                       properties:
                         _id:
                           type: integer
-                          description: Character's ID.                        
+                          description: Character's ID.
                         films:
                           type: array
                           description: The films in which the character participates.
@@ -158,16 +166,19 @@ paths:
                           description: API URL for the character's detail.
   /characters/{id}:
     get:
-      description: Retrieves information about a single character based on its id.
+      tags:
+        - "Characters"
+      description: Retrieves information about a single character based on its id.\
+      operationId: GetChracterById
       parameters:
-      - name: id
-        in: path
-        required: true
-        description: The character's id
-        schema:
-          type: integer
+        - name: id
+          in: path
+          required: true
+          description: The character's id
+          schema:
+            type: integer
       responses:
-        '200':
+        "200":
           description: Successfully returned a character
           content:
             application/json:
@@ -221,4 +232,5 @@ paths:
                   url:
                     type: string
                     description: API URL for the character's detail.
-                      
+tags:
+  - name: Characters


### PR DESCRIPTION
Hi vbrenck,

I noticed that the OpenAPI spec file for the API is missing the operationId and tags properties for some of the operations. To help improve the documentation and ease of use for the API, I've added these properties to the affected operations.

Here are the specific changes that I made:
- For each operation that was missing an operationId property, I added a unique and descriptive operationId value to help identify the operation in the documentation and code.
- For each operation that was missing a tags property, I added one or more relevant tags to help group related operations together and make it easier to navigate the documentation.                          

I've tested these changes locally and everything looks good. Please let me know if you have any questions or concerns about these changes.

Thanks,